### PR TITLE
Fix the defaults to use procs for lazy evaluation.

### DIFF
--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -31,11 +31,11 @@ end
 
 namespace :load do
   task :defaults do
-    set :bundle_gemfile, release_path.join('Gemfile')
-    set :bundle_dir, shared_path.join('vendor/bundle')
-    set :bundle_flags, '--deployment'
+    set :bundle_gemfile, -> { release_path.join('Gemfile') }
+    set :bundle_dir, -> { shared_path.join('bundle') }
+    set :bundle_flags, '--deployment --quiet'
     set :bundle_without, %w{development test}.join(' ')
-    set :bundle_binstubs, shared_path.join('bin')
+    set :bundle_binstubs, -> { shared_path.join('bin') }
     set :bundle_roles, :all
   end
 end


### PR DESCRIPTION
Without this, the bundle_gemfile setting was being set to the 'current' directory
instead of the actual release path because release_path is not set yet when the
defaults get set.
