### PR TITLE
Fix for "unexpected tQWORDS_BEG" in readme example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ By default, the plugin adds `bundle exec` prefix to common executables listed in
 
 You can add any custom executable to this list:
 ```ruby
-set :bundle_bins, fetch(:bundle_bins, []).push %w(my_new_binary)
+set :bundle_bins, fetch(:bundle_bins, []).push(%w{ my_new_binary })
 ```
 
 Configurable options:


### PR DESCRIPTION
Fixes:

```
syntax error, unexpected tQWORDS_BEG, expecting end-of-input
set :bundle_bins, fetch(:bundle_bins, []).push %w(delayed_job)
```
