### PR TITLE
Lets use inline array instead passed array as param

### DIFF
--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -16,7 +16,7 @@ namespace :bundler do
           set :bundle_flags, '--deployment --quiet'
     DESC
   task :install do
-    on roles fetch(:bundle_roles) do
+    on roles(*fetch(:bundle_roles)) do
       within release_path do
         options = ["install"]
         options << "--binstubs #{fetch(:bundle_binstubs)}" if fetch(:bundle_binstubs)


### PR DESCRIPTION
Example of the problem:

```
set :bundle_roles, %w{web jobs}
```

For the current version it will raise exception on role_filter like:

```
undefined method `to_sym' for ["web", "jobs"]:Array
vendor/bundle/ruby/2.1.0/gems/capistrano-3.0.1/lib/capistrano/configuration/servers/role_filter.rb:25:in `each'
```

Example for this change: https://gist.github.com/oivoodoo/8342230
