### PR TITLE
Updates bundle_path to match capistrano default

### DIFF
--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -14,7 +14,7 @@ namespace :bundler do
           set :bundle_servers, -> { release_roles(fetch(:bundle_roles)) }
           set :bundle_binstubs, -> { shared_path.join('bin') }
           set :bundle_gemfile, -> { release_path.join('Gemfile') }
-          set :bundle_path, -> { shared_path.join('bundle') }
+          set :bundle_path, -> { shared_path.join('vendor','bundle') }
           set :bundle_without, %w{development test}.join(' ')
           set :bundle_flags, '--deployment --quiet'
           set :bundle_jobs, nil
@@ -64,7 +64,7 @@ namespace :load do
     set :bundle_roles, :all
     set :bundle_servers, -> { release_roles(fetch(:bundle_roles)) }
     set :bundle_binstubs, -> { shared_path.join('bin') }
-    set :bundle_path, -> { shared_path.join('bundle') }
+    set :bundle_path, -> { shared_path.join('vendor', 'bundle') }
     set :bundle_without, %w{development test}.join(' ')
     set :bundle_flags, '--deployment --quiet'
   end


### PR DESCRIPTION
The linked directories in capistrano proper expects to symlink the `shared/vendor/bundle` to `current/vendor/bundle`. The former default setting puts the bundled gems in 'shared/bundle' which is not symlinked correctly by the default capistrano settings.

The consequences of this will only rear its ugly head when you have an older version of Bundler. Basically, Passenger would not start the app due to missing gems. When we investigated we found the `vendor/bundle` (symlink-ed from shared) folder was empty.  We had version 1.3.5 of Bundler and once we updated it to 1.5.3 the app started up without a problem. We assume this is because Bundler fell back to using the global gems in our ruby install when it found the empty `vendor/bundle` folder
