### PR TITLE
Add --clean options to bundle defaults flags

### DIFF
--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -66,6 +66,6 @@ namespace :load do
     set :bundle_binstubs, -> { shared_path.join('bin') }
     set :bundle_path, -> { shared_path.join('bundle') }
     set :bundle_without, %w{development test}.join(' ')
-    set :bundle_flags, '--deployment --quiet'
+    set :bundle_flags, '--deployment --quiet --clean'
   end
 end


### PR DESCRIPTION
Prevent building huge gems cache over time.

Since default Capistrano setup is to install gems in shared/bundle cache, I see no use to keep old gems (won't conflict with other deployments using older gems for exemple). I have projects where over a 1 to 2 years period we have build a cache of up to 1-2gb of gems versions.