### PR TITLE
Set default bundle_path to vendor/bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ set :bundle_roles, :all                                         # this is defaul
 set :bundle_servers, -> { release_roles(fetch(:bundle_roles)) } # this is default
 set :bundle_binstubs, -> { shared_path.join('bin') }            # default: nil
 set :bundle_gemfile, -> { release_path.join('MyGemfile') }      # default: nil
-set :bundle_path, -> { shared_path.join('bundle') }             # this is default
+set :bundle_path, -> { shared_path.join('vendor', 'bundle') }   # this is default
 set :bundle_without, %w{development test}.join(' ')             # this is default
 set :bundle_flags, '--deployment --quiet'                       # this is default
 set :bundle_env_variables, {}                                   # this is default

--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -14,7 +14,7 @@ namespace :bundler do
           set :bundle_servers, -> { release_roles(fetch(:bundle_roles)) }
           set :bundle_binstubs, -> { shared_path.join('bin') }
           set :bundle_gemfile, -> { release_path.join('Gemfile') }
-          set :bundle_path, -> { shared_path.join('bundle') }
+          set :bundle_path, -> { shared_path.join('vendor', 'bundle') }
           set :bundle_without, %w{development test}.join(' ')
           set :bundle_flags, '--deployment --quiet'
           set :bundle_jobs, nil
@@ -63,7 +63,7 @@ namespace :load do
 
     set :bundle_roles, :all
     set :bundle_servers, -> { release_roles(fetch(:bundle_roles)) }
-    set :bundle_path, -> { shared_path.join('bundle') }
+    set :bundle_path, -> { shared_path.join('vendor', 'bundle') }
     set :bundle_without, %w{development test}.join(' ')
     set :bundle_flags, '--deployment --quiet'
   end


### PR DESCRIPTION
Capistrano's suggested linked_dirs includes vendor/bundle
and rails looks for gems in vendor/bundle so it makes sense
to set this as the default.
https://github.com/capistrano/capistrano/blob/master/lib/capistrano/templates/deploy.rb.erb#L29

Also, reformat the README.md default comments.