### PR TITLE
Add optional loading of hooks.

### DIFF
--- a/lib/capistrano/bundler.rb
+++ b/lib/capistrano/bundler.rb
@@ -1,1 +1,2 @@
-load File.expand_path('../tasks/bundler.cap', __FILE__)
+require_relative 'bundler/tasks'
+require_relative 'bundler/hooks'

--- a/lib/capistrano/bundler/hooks.rb
+++ b/lib/capistrano/bundler/hooks.rb
@@ -1,0 +1,1 @@
+load File.expand_path('../../tasks/hooks.cap', __FILE__)

--- a/lib/capistrano/bundler/tasks.rb
+++ b/lib/capistrano/bundler/tasks.rb
@@ -1,0 +1,1 @@
+load File.expand_path('../../tasks/bundler.cap', __FILE__)

--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -49,8 +49,6 @@ namespace :bundler do
       SSHKit.config.command_map.prefix[command.to_sym].push("bundle exec")
     end
   end
-
-  before 'deploy:updated', 'bundler:install'
 end
 
 Capistrano::DSL.stages.each do |stage|

--- a/lib/capistrano/tasks/hooks.cap
+++ b/lib/capistrano/tasks/hooks.cap
@@ -1,0 +1,1 @@
+before 'deploy:updated', 'bundler:install'


### PR DESCRIPTION
This allows a user to require only the tasks and ignore the task hook. We use this because we run bundler at a different point during the deploy.

I have made a similar pull request to capistrano/rails which seemed to be well accepted (although not merged yet, for some reason). I have also suggested an alternate solution there. 

https://github.com/capistrano/rails/pull/68