### PR TITLE
Execute bundler in subdirectory

### DIFF
--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -32,7 +32,13 @@ namespace :bundler do
           options << "--jobs #{fetch(:bundle_jobs)}" if fetch(:bundle_jobs)
           options << "#{fetch(:bundle_flags)}" if fetch(:bundle_flags)
 
-          execute :bundle, options
+          if fetch(:bundle_subdir)
+            within fetch(:bundle_subdir) do
+              execute :bundle, options
+            end
+          else
+            execute :bundle, options
+          end
         end
       end
     end


### PR DESCRIPTION
Sometimes we have Git repositories with the app that we want to deploy in a subdirectory. In those cases, we would need to execute `bundle install` in the subdirectory.

It can be enabled by adding a line like this to the `config/deploy.rb` file:

```
set :bundle_subdir, 'frontend'
```

If you accept this proposal, I will also update the documentation. Also, there might be better names for the config value,
