### PR TITLE
Add missing parens to bundle_bins example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ By default, the plugin adds `bundle exec` prefix to common executables listed in
 
 You can add any custom executable to this list:
 ```ruby
-set :bundle_bins, fetch(:bundle_bins, []).push 'my_new_binary'
+set :bundle_bins, fetch(:bundle_bins, []).push('my_new_binary')
 ```
 
 Configurable options:


### PR DESCRIPTION
The Ruby parser thinks (rightly) that it's ambiguous to have no parens around the argument to a method called as an argument to a method. If you get my meaning.
