### PR TITLE
Fix code example in description

### DIFF
--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -42,7 +42,7 @@ namespace :bundler do
         Maps all binaries to use `bundle exec` by default.
         Add your own binaries to the array with the command shown below.
 
-          set :bundle_bins, fetch(:bundle_bins).push %w(my_new_binary)
+          set :bundle_bins, fetch(:bundle_bins) + %w(my_new_binary)
     DESC
   task :map_bins do
     fetch(:bundle_bins).each do |command|


### PR DESCRIPTION
Current example is invalid:

```
SyntaxError: config/deploy.rb:74: syntax error, unexpected tQWORDS_BEG, expecting end-of-input
set :bundle_bins, fetch(:bundle_bins).push %w(my_bin)
```