### PR TITLE
use default bundle_path in deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+(master)
+
+* Add `vendor/bundle/` to `linked_dirs`.
+* Set default for `bundle_path` to `nil`, which means Bundler chooses `vendor/bundle/`.
+    * If you did not change the default `bundle_path` make sure to cleanup the
+      old bundle path `shared/bundle/` which is now unused. The new default is
+      `shared/vendor/bundle/`.
+
 # 1.1.4 (22 Jan 2014)
 
 * Don’t generate binstubs by default (#61)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ set :bundle_roles, :all                                         # this is defaul
 set :bundle_servers, -> { release_roles(fetch(:bundle_roles)) } # this is default
 set :bundle_binstubs, -> { shared_path.join('bin') }            # default: nil
 set :bundle_gemfile, -> { release_path.join('MyGemfile') }      # default: nil
-set :bundle_path, -> { shared_path.join('bundle') }             # this is default
+set :bundle_path, -> { shared_path.join('my_special_bundle') }  # default: nil
 set :bundle_without, %w{development test}.join(' ')             # this is default
 set :bundle_flags, '--deployment --quiet'                       # this is default
 set :bundle_env_variables, {}                                   # this is default
@@ -71,6 +71,11 @@ To generate binstubs on each deploy, set `:bundle_binstubs` path:
 ```ruby
 set :bundle_binstubs, -> { shared_path.join('bin') }
 ```
+
+Bundler uses `vendor/bundle/` as path for gems if called with `--deployment`.
+Therefore this gem adds that path to `linked_dirs`. See the [Bundler
+documentation](http://bundler.io/v1.7/man/bundle-install.1.html#DEPLOYMENT-MODE)
+for details.
 
 In the result this would execute the following bundle command on all servers
 (actual paths depend on the real deploy directory):

--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -14,7 +14,7 @@ namespace :bundler do
           set :bundle_servers, -> { release_roles(fetch(:bundle_roles)) }
           set :bundle_binstubs, -> { shared_path.join('bin') }
           set :bundle_gemfile, -> { release_path.join('Gemfile') }
-          set :bundle_path, -> { shared_path.join('bundle') }
+          set :bundle_path, -> { shared_path.join('my_special_bundle') }
           set :bundle_without, %w{development test}.join(' ')
           set :bundle_flags, '--deployment --quiet'
           set :bundle_jobs, nil
@@ -63,8 +63,10 @@ namespace :load do
 
     set :bundle_roles, :all
     set :bundle_servers, -> { release_roles(fetch(:bundle_roles)) }
-    set :bundle_path, -> { shared_path.join('bundle') }
+    set :bundle_path, nil
     set :bundle_without, %w{development test}.join(' ')
     set :bundle_flags, '--deployment --quiet'
+
+    set :linked_dirs, fetch(:linked_dirs, []).push('vendor/bundle')
   end
 end


### PR DESCRIPTION
closes #46 
closes #50 
fixes #58 

If Bundler is run with --deployment the default path for gems is vendor/bundle. Therefore putting this path into linked_dirs is a simple solution to speedup gem installation.

Please see previous discussion in #46 and #58.

/cc @kirs @jgeiger @Altonymous @blackjid