### PR TITLE
add hook for rollbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 (master)
 
+* Add hook to `bundle:install` before `deploy:reverted`.
 * Add `vendor/bundle/` to `linked_dirs`.
 * Set default for `bundle_path` to `nil`, which means Bundler chooses `vendor/bundle/`.
     * If you did not change the default `bundle_path` make sure to cleanup the

--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -51,6 +51,7 @@ namespace :bundler do
   end
 
   before 'deploy:updated', 'bundler:install'
+  before 'deploy:reverted', 'bundler:install'
 end
 
 Capistrano::DSL.stages.each do |stage|


### PR DESCRIPTION
I propose running `bundle:install` as part of a rollback.
If you rollback to an older release, but maybe you already cleaned up some stuff, this will run bundler again to ensure all required gems are installed.

I guess the rollback workflow in general is still a bit broken - but this should streamline it a little.