### PR TITLE
adding 'bundle_cmd' option instead of executing 'bundle'

### DIFF
--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -47,7 +47,7 @@ namespace :bundler do
     DESC
   task :map_bins do
     fetch(:bundle_bins).each do |command|
-      SSHKit.config.command_map.prefix[command.to_sym].push("bundle exec")
+      SSHKit.config.command_map.prefix[command.to_sym].push("#{fetch(:bundle_cmd)} exec")
     end
   end
 

--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -11,6 +11,7 @@ namespace :bundler do
 
           set :bundle_roles, :all
 
+          set :bundle_cmd, 'bundle'
           set :bundle_servers, -> { release_roles(fetch(:bundle_roles)) }
           set :bundle_binstubs, -> { shared_path.join('bin') }
           set :bundle_gemfile, -> { release_path.join('Gemfile') }
@@ -32,7 +33,7 @@ namespace :bundler do
           options << "--jobs #{fetch(:bundle_jobs)}" if fetch(:bundle_jobs)
           options << "#{fetch(:bundle_flags)}" if fetch(:bundle_flags)
 
-          execute :bundle, options
+          execute fetch(:bundle_cmd), options
         end
       end
     end
@@ -61,6 +62,7 @@ namespace :load do
   task :defaults do
     set :bundle_bins, %w{gem rake rails}
 
+    set :bundle_cmd, 'bundle'
     set :bundle_roles, :all
     set :bundle_servers, -> { release_roles(fetch(:bundle_roles)) }
     set :bundle_path, nil


### PR DESCRIPTION
Hey guys,

when deploying ruby applications, I prefer to compile and install ruby from source (by using [postmortem's ruby-install](https://github.com/postmodern/ruby-install), which is really useful).

And I like to keep things separated-- my ruby is on _/opt/rubies/ruby2.2.2_. Thing is, right now there's no way to change the "bundle" command (other than messing around with $PATH, which is something I'd rather keep intact). I need to run _/opt/rubies/ruby-2.2.2/bin/bundle_ instead of _bundle_.

What do you think of adding this simple extra option? I've been using my fork with _set :bundle_cmd, "/opt/rubies/ruby-2.2.2/bin/bundle"_ and it works like a charm.