### PR TITLE
Changed default bundle_path from a relative path to absolute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ set :bundle_roles, :all                                         # this is defaul
 set :bundle_servers, -> { release_roles(fetch(:bundle_roles)) } # this is default
 set :bundle_binstubs, -> { shared_path.join('bin') }            # default: nil
 set :bundle_gemfile, -> { release_path.join('MyGemfile') }      # default: nil
-set :bundle_path, -> { shared_path.join('my_special_bundle') }  # default: nil
+set :bundle_path, -> { shared_path.join('my_special_bundle') }  # default: shared_path.join('vendor/bundle')
 set :bundle_without, %w{development test}.join(' ')             # this is default
 set :bundle_flags, '--deployment --quiet'                       # this is default
 set :bundle_env_variables, {}                                   # this is default

--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -63,7 +63,7 @@ namespace :load do
 
     set :bundle_roles, :all
     set :bundle_servers, -> { release_roles(fetch(:bundle_roles)) }
-    set :bundle_path, nil
+    set :bundle_path, -> { shared_path.join('vendor/bundle') }
     set :bundle_without, %w{development test}.join(' ')
     set :bundle_flags, '--deployment --quiet'
 


### PR DESCRIPTION
Because Capistrano cleans up old releases,
the default `bundle_path` (`'vendor/bundle'`) causes problems with
long-running tasks, e.g. unicorn.

In unicorn the master process spawns new child processes to reload the
application, typically as part of a new `cap foo deploy`.
To do this it has to find the `unicorn` binary again.
The problem is that if you initially start the unicorn master process
with a cwd of `/var/www/foo/releases/12345`
plus a `bundle_path` of `vendor/bundle`,
then the path to the `unicorn` binary won't exist a few deploys later,
and unicorn will fail to start new workers.
But with a cwd of `/var/www/foo/releases/12345`
plus a `bundle_path` of `/var/www/foo/shared/vendor/bundle`,
the `unicorn` binary's path is all permanent elements,
so reloading will work indefinitely.