### PR TITLE
Fix bundle check problem

### DIFF
--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -25,12 +25,11 @@ namespace :bundler do
       within release_path do
         with fetch(:bundle_env_variables, {}) do
           options = []
-          options << "--binstubs #{fetch(:bundle_binstubs)}" if fetch(:bundle_binstubs)
           options << "--gemfile #{fetch(:bundle_gemfile)}" if fetch(:bundle_gemfile)
           options << "--path #{fetch(:bundle_path)}" if fetch(:bundle_path)
-          options << "--jobs #{fetch(:bundle_jobs)}" if fetch(:bundle_jobs)
-
           unless test(:bundle, :check, *options)
+            options << "--binstubs #{fetch(:bundle_binstubs)}" if fetch(:bundle_binstubs)
+            options << "--jobs #{fetch(:bundle_jobs)}" if fetch(:bundle_jobs)
             options << "--without #{fetch(:bundle_without)}" if fetch(:bundle_without)
             options << "#{fetch(:bundle_flags)}" if fetch(:bundle_flags)
             execute :bundle, :install, *options


### PR DESCRIPTION
### Problem
Bundler install executes every deployment, although the dependencies are not changed.
Because `bundle check` doesn't accept options `jobs` and `binstubs`,
so if we set `bundle_jobs` or `bundle_binstubs`, `test(:bundle, :check, *options)` 
would return `false` every time.

### Changes
Don't pass unnecessary options `jobs` and `binstubs` for `bundle check`.

Thanks.