### PR TITLE
Change default path back to shared_path/bundle

### DIFF
--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -63,7 +63,7 @@ namespace :load do
 
     set :bundle_roles, :all
     set :bundle_servers, -> { release_roles(fetch(:bundle_roles)) }
-    set :bundle_path, -> { shared_path.join('vendor/bundle') }
+    set :bundle_path, -> { shared_path.join('bundle') }
     set :bundle_without, %w{development test}.join(' ')
     set :bundle_flags, '--deployment --quiet'
 


### PR DESCRIPTION
The default :bundle_path has always been `shared_path.join('bundle')` and says so in the README and in the `bundle:install` task description. However during a [recent revert commit](https://github.com/capistrano/bundler/commit/6b23e523c337d966457e4c034a5e86b902ebcc4c), somehow it was changed to `shared_path.join('vendor/bundle')`. I assume this was done inadvertently.

By fixing this, we avoid a problem when users upgrade capistrano-bundler and find that their bundler directory has suddenly changed and all their gems are being re-downloaded.