### PR TITLE
Remove change to :linked_dirs

### DIFF
--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -77,7 +77,5 @@ namespace :load do
     set :bundle_path, -> { shared_path.join('bundle') }
     set :bundle_without, %w{development test}.join(' ')
     set :bundle_flags, '--deployment --quiet'
-
-    set :linked_dirs, fetch(:linked_dirs, []) << '.bundle'
   end
 end


### PR DESCRIPTION
Commit 6b23e52 was supposed to fully revert 9414388, but it accidentally left in a change to the `:linked_dirs` variable. This commit completes the revert of 9414388.