### PR TITLE
Add hanami to bundle_bins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [Unreleased][] (master)
 
-* Your contribution here!
+* Add hanami to `bundle_bins`
 
 # [1.2.0][] (1 Oct 2016)
 

--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -70,7 +70,7 @@ end
 
 namespace :load do
   task :defaults do
-    set :bundle_bins, %w{gem rake rails}
+    set :bundle_bins, %w{gem rake rails hanami}
 
     set :bundle_roles, :all
     set :bundle_servers, -> { release_roles(fetch(:bundle_roles)) }


### PR DESCRIPTION
This is necessary so that you can run the command `hanami` through method` execute`.

[Hanami](https://github.com/hanami/hanami) is a full-stack Ruby web framework.

Example:
```ruby
namespace :deploy do
  task :hanami_help do
    on roles(:app) do
      within release_path do
        with hanami_env: fetch(:hanami_env) do
          execute :hanami, 'help'
        end
      end
    end
  end
end
```