### PR TITLE
At readme, specify recommended way.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It also prefixes certain binaries to use `bundle exec`.
 
 ## Installation
 
-Add these lines to your application's Gemfile:
+Add these lines to your application's Gemfile **[Recommended]**:
 
 ```ruby
 gem 'capistrano', '~> 3.6'


### PR DESCRIPTION
Hello I am Yuichiro Suzuki(u16suzu) from Japan.
I have an opinion to README.

### What's problem?
- At [README's Installation](https://github.com/capistrano/bundler/blob/master/README.md#installation),
I could not decide which one is the best installation way (install to system or local directory).
- If you have a recommendation way, the way should be written on installation.

```text
Add these lines to your application's Gemfile:

gem 'capistrano', '~> 3.6'
gem 'capistrano-bundler', '~> 1.2'

And then execute:

$ bundle

Or install it yourself as:

$ gem install capistrano-bundler
```

### Expected
- For avoiding unintended effects to other projects on local machine.
- I think, the gem should be install to project's local directory by installation using Gemfile.

### Solution idea
How about adding [Recommended] to the recommended way like the following:

```text
Add these lines to your application's Gemfile **[Recommended]**:

gem 'capistrano', '~> 3.6'
gem 'capistrano-bundler', '~> 1.2'

And then execute:

$ bundle

Or install it yourself as:

$ gem install capistrano-bundler
```
