### PR TITLE
Allow configuration of SSHKit options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [Unreleased][] (master)
 
 * Your contribution here!
+* Add `bundle_task_ssh_kit_options` option to configure SSHKit options
 
 # [1.2.0][] (1 Oct 2016)
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ set :bundle_without, %w{development test}.join(' ')             # this is defaul
 set :bundle_flags, '--deployment --quiet'                       # this is default
 set :bundle_env_variables, {}                                   # this is default
 set :bundle_clean_options, ""                                   # this is default. Use "--dry-run" if you just want to know what gems would be deleted, without actually deleting them
+set :bundle_task_ssh_kit_options, { in: :groups, limit: 50 }    # default {}
 ```
 
 You can parallelize the installation of gems with bundler's jobs feature.

--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -22,7 +22,7 @@ namespace :bundler do
           set :bundle_clean_options, ""
     DESC
   task :install do
-    on fetch(:bundle_servers) do
+    on fetch(:bundle_servers), fetch(:bundle_task_ssh_kit_options, {}) do
       within release_path do
         with fetch(:bundle_env_variables, {}) do
           options = []
@@ -54,7 +54,7 @@ namespace :bundler do
 
   desc "Remove unused gems installed by bundler"
   task :clean do
-    on fetch(:bundle_servers) do
+    on fetch(:bundle_servers), fetch(:bundle_task_ssh_kit_options, {}) do
       within release_path do
         with fetch(:bundle_env_variables, {}) do
           execute :bundle, :clean, fetch(:bundle_clean_options, "")


### PR DESCRIPTION
I found this useful to work around a rate limit with a custom gem repo :)
There may be other applications.

e.g. `set :bundle_task_ssh_kit_options, { in: :groups, limit: 50 }`