### PR TITLE
Set all variable defaults in load:defaults task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [Unreleased][] (master)
 
 * Your contribution here!
+* Set all variables in `load:defaults` task so they are recognised as valid Capistrano settings when using `doctor:variables` and ensure defaults for `bundle_env_variables` and `bundle_clean_options` are set once in the same place as the other defaults.
 
 # [1.2.0][] (1 Oct 2016)
 

--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -24,7 +24,7 @@ namespace :bundler do
   task :install do
     on fetch(:bundle_servers) do
       within release_path do
-        with fetch(:bundle_env_variables, {}) do
+        with fetch(:bundle_env_variables) do
           options = []
           options << "--gemfile #{fetch(:bundle_gemfile)}" if fetch(:bundle_gemfile)
           options << "--path #{fetch(:bundle_path)}" if fetch(:bundle_path)
@@ -56,8 +56,8 @@ namespace :bundler do
   task :clean do
     on fetch(:bundle_servers) do
       within release_path do
-        with fetch(:bundle_env_variables, {}) do
-          execute :bundle, :clean, fetch(:bundle_clean_options, "")
+        with fetch(:bundle_env_variables) do
+          execute :bundle, :clean, fetch(:bundle_clean_options)
         end
       end
     end
@@ -74,8 +74,13 @@ namespace :load do
 
     set :bundle_roles, :all
     set :bundle_servers, -> { release_roles(fetch(:bundle_roles)) }
+    set :bundle_binstubs, nil
+    set :bundle_gemfile, nil
     set :bundle_path, -> { shared_path.join('bundle') }
     set :bundle_without, %w{development test}.join(' ')
     set :bundle_flags, '--deployment --quiet'
+    set :bundle_jobs, nil
+    set :bundle_env_variables, {}
+    set :bundle_clean_options, ""
   end
 end


### PR DESCRIPTION
When I ran the `doctor:variables` task, it reported that `bundle_jobs` was not a recognized Capistrano setting. This led me to creating this PR which defines a default for each configuration variable in the `load:defaults` task, even if it is nil. Now all the variables appear in the `doctor:variables` list.