### PR TITLE
Speed up `bundle install` when gems did not change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [Unreleased][] (master)
 
 * Your contribution here!
+* [#99](https://github.com/capistrano/bundler/pull/99): Speed up `bundle install` when gems did not change - [@vassilevsky](https://github.com/vassilevsky)
 
 # [1.3.0][] (22 Sep 2017)
 

--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -33,7 +33,8 @@ namespace :bundler do
             options << "--jobs #{fetch(:bundle_jobs)}" if fetch(:bundle_jobs)
             options << "--without #{fetch(:bundle_without)}" if fetch(:bundle_without)
             options << "#{fetch(:bundle_flags)}" if fetch(:bundle_flags)
-            execute :bundle, :install, *options
+            fast_options = options + ['--local']
+            test :bundle, :install, *fast_options or execute :bundle, :install, *options
           end
         end
       end


### PR DESCRIPTION
Hello everyone!

Bundler has the `--local` flag that disables expensive network requests. Makes sense to try it first.

If gems are not yet installed on the server, it will fail. In this case, the "normal" command will be executed. It will download new gems.

The drawback of this solution is that the local command is not printed. Doesn't look like a big deal though. The "normal" command is printed. Please do let me know if it's better to print the original as well, and how, because I don't have a clear idea.

I have tested this change on a real project. Deployment time dropped by ~20 seconds. The server is in Moscow.