### PR TITLE
Add .bundle dir to :linked_dirs automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # [Unreleased][] (master)
 
+Added
+
+* Auto-add `.bundle` directory to Capistrano's `:linked_dirs` configuration variable, making the directory persistent across releases. In particular, this fixes `bundle check` operation, which speeds up consequent deployments.
 * Your contribution here!
 
 # [1.3.0][] (22 Sep 2017)

--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -62,6 +62,14 @@ namespace :bundler do
       end
     end
   end
+
+  desc "Make the .bundle directory persistent across deploys (for faster bundling)"
+  task :set_linked_dirs do
+    linked_dirs = fetch :linked_dirs, []
+    unless linked_dirs.include?('.bundle')
+      set :linked_dirs, linked_dirs + ['.bundle']
+    end
+  end
 end
 
 Capistrano::DSL.stages.each do |stage|

--- a/lib/capistrano/tasks/hooks.cap
+++ b/lib/capistrano/tasks/hooks.cap
@@ -1,2 +1,3 @@
+after 'bundler:map_bins', 'bundler:set_linked_dirs'
 before 'deploy:updated', 'bundler:install'
 before 'deploy:reverted', 'bundler:install'


### PR DESCRIPTION
Possible solution of #96 requiring no user interaction at all (except for the gem update).

Repeated after `capistrano-rails`.

https://github.com/capistrano/rails/blob/master/lib/capistrano/tasks/assets.rake#L126