### PR TITLE
Set bundle options before check via bundle config

### DIFF
--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -24,14 +24,23 @@ namespace :bundler do
   task :install do
     on fetch(:bundle_servers) do
       within release_path do
-        with fetch(:bundle_env_variables) do
-          options = []
-          options << "--gemfile #{fetch(:bundle_gemfile)}" if fetch(:bundle_gemfile)
-          options << "--path #{fetch(:bundle_path)}" if fetch(:bundle_path)
-          unless test(:bundle, :check, *options)
+        with fetch(:bundle_env_variables, {}) do
+          bundle_path = fetch(:bundle_path)
+          bundle_without = fetch(:bundle_without)
+          bundle_gemfile = fetch(:bundle_gemfile)
+          bundle_frozen = fetch(:bundle_frozen)
+          bundle_disable_shared_gems = fetch(:bundle_disable_shared_gems)
+
+          execute :bundle, :config, "--local path #{bundle_path}" if bundle_path
+          execute :bundle, :config, "--local without #{bundle_without.split(' ').join(':')}" if bundle_without
+          execute :bundle, :config, "--local gemfile #{bundle_gemfile}" if bundle_gemfile
+          execute :bundle, :config, "--local frozen #{bundle_frozen}" if bundle_frozen
+          execute :bundle, :config, "--local disable_shared_gems #{bundle_disable_shared_gems}" if bundle_disable_shared_gems
+
+          unless test(:bundle, :check)
+            options = []
             options << "--binstubs #{fetch(:bundle_binstubs)}" if fetch(:bundle_binstubs)
             options << "--jobs #{fetch(:bundle_jobs)}" if fetch(:bundle_jobs)
-            options << "--without #{fetch(:bundle_without)}" if fetch(:bundle_without)
             options << "#{fetch(:bundle_flags)}" if fetch(:bundle_flags)
             execute :bundle, :install, *options
           end
@@ -82,5 +91,7 @@ namespace :load do
     set :bundle_jobs, nil
     set :bundle_env_variables, {}
     set :bundle_clean_options, ""
+    set :bundle_frozen, '1'
+    set :bundle_disable_shared_gems, true
   end
 end


### PR DESCRIPTION
Hello, @mattbrictson !

This PR is advances idea, discussed in #97 

Here I take two more options into account: `bundle_frozen` and `bundle_disable_shared_gems`
#97 still has problem I'm trying to solve here, setting 3 options is happened to be not enough.

```ruby
# default values for new options
set :bundle_frozen, '1'
set :bundle_disable_shared_gems, true
```

Now I set 5 bundle config options before `bundle check`:
```ruby
execute :bundle, :config, "--local path #{bundle_path}" if bundle_path
execute :bundle, :config, "--local without #{bundle_without.split(' ').join(':')}" if bundle_without
execute :bundle, :config, "--local gemfile #{bundle_gemfile}" if bundle_gemfile
execute :bundle, :config, "--local frozen #{bundle_frozen}" if bundle_frozen
execute :bundle, :config, "--local disable_shared_gems #{bundle_disable_shared_gems}" if bundle_disable_shared_gems
```

Code from this PR is battle-tested, we already use it in production.

Though we are adding 5 more commands, we still have order-of-magnitude win.
`bundle` command may take more than 25 seconds to fetch metadata.

5 `bundle config` commands take about 1,5 seconds for us in deploy to 3 app-servers with 50ms ping.

With faster ping 5 `bundle config` will take even less time.