### PR TITLE
Explicitly report that the installation command is not required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [Unreleased][] (master)
 
 * Your contribution here!
+* Explicitly reporting that the installation command is not required
 
 # [1.3.0][] (22 Sep 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # [Unreleased][] (master)
 
 * Your contribution here!
-* Explicitly reporting that the installation command is not required
+* When "bundle install| is skipped due to a Gemfile's dependencies are being satisfied, print a message to the log instead of silently skipping
 
 # [1.3.0][] (22 Sep 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # [Unreleased][] (master)
 
 * Your contribution here!
-* When "bundle install| is skipped due to a Gemfile's dependencies are being satisfied, print a message to the log instead of silently skipping
+* When "bundle install" is skipped due to a Gemfile's dependencies are being satisfied, print a message to the log instead of silently skipping
 
 # [1.3.0][] (22 Sep 2017)
 

--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -34,6 +34,8 @@ namespace :bundler do
             options << "--without #{fetch(:bundle_without)}" if fetch(:bundle_without)
             options << "#{fetch(:bundle_flags)}" if fetch(:bundle_flags)
             execute :bundle, :install, *options
+          else
+            output.log("The Gemfile's dependencies are satisfied, skipping installation")
           end
         end
       end

--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -28,14 +28,14 @@ namespace :bundler do
           options = []
           options << "--gemfile #{fetch(:bundle_gemfile)}" if fetch(:bundle_gemfile)
           options << "--path #{fetch(:bundle_path)}" if fetch(:bundle_path)
-          unless test(:bundle, :check, *options)
+          if test(:bundle, :check, *options)
+            output.log("The Gemfile's dependencies are satisfied, skipping installation")
+          else
             options << "--binstubs #{fetch(:bundle_binstubs)}" if fetch(:bundle_binstubs)
             options << "--jobs #{fetch(:bundle_jobs)}" if fetch(:bundle_jobs)
             options << "--without #{fetch(:bundle_without)}" if fetch(:bundle_without)
             options << "#{fetch(:bundle_flags)}" if fetch(:bundle_flags)
             execute :bundle, :install, *options
-          else
-            output.log("The Gemfile's dependencies are satisfied, skipping installation")
           end
         end
       end

--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -29,7 +29,7 @@ namespace :bundler do
           options << "--gemfile #{fetch(:bundle_gemfile)}" if fetch(:bundle_gemfile)
           options << "--path #{fetch(:bundle_path)}" if fetch(:bundle_path)
           if test(:bundle, :check, *options)
-            output.log("The Gemfile's dependencies are satisfied, skipping installation")
+            info "The Gemfile's dependencies are satisfied, skipping installation"
           else
             options << "--binstubs #{fetch(:bundle_binstubs)}" if fetch(:bundle_binstubs)
             options << "--jobs #{fetch(:bundle_jobs)}" if fetch(:bundle_jobs)


### PR DESCRIPTION
If there's nothing to install, the `bundler:install` task is not going to show up in the console output or logs, which could create a moment of puzzlement to newer folks. Since it's not really possible to see in this case whether the gem is configured correctly or even operates at all. 

I propose instead to show a one-line message to document that it goes as expected:
```
00:06 bundler:install
           The Gemfile's dependencies are satisfied, skipping installation
```