### PR TITLE
Use setting to determine if test should be ran for full installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [Unreleased][] (master)
 
-* Your contribution here!
+* Added `bundle_check_before_install` option to allow bypassing the `bundle install test` in the `bundler:install` task.
 
 # [1.3.0][] (22 Sep 2017)
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ set :bundle_without, %w{development test}.join(' ')             # this is defaul
 set :bundle_flags, '--deployment --quiet'                       # this is default
 set :bundle_env_variables, {}                                   # this is default
 set :bundle_clean_options, ""                                   # this is default. Use "--dry-run" if you just want to know what gems would be deleted, without actually deleting them
+set :bundle_check_before_install, true                          # default: true. Set this to false to bypass running `bundle check` before executing `bundle install`
 ```
 
 You can parallelize the installation of gems with bundler's jobs feature.

--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -28,7 +28,8 @@ namespace :bundler do
           options = []
           options << "--gemfile #{fetch(:bundle_gemfile)}" if fetch(:bundle_gemfile)
           options << "--path #{fetch(:bundle_path)}" if fetch(:bundle_path)
-          unless test(:bundle, :check, *options)
+
+          unless fetch(:bundle_check_before_install) && test(:bundle, :check, *options)
             options << "--binstubs #{fetch(:bundle_binstubs)}" if fetch(:bundle_binstubs)
             options << "--jobs #{fetch(:bundle_jobs)}" if fetch(:bundle_jobs)
             options << "--without #{fetch(:bundle_without)}" if fetch(:bundle_without)
@@ -82,5 +83,6 @@ namespace :load do
     set :bundle_jobs, nil
     set :bundle_env_variables, {}
     set :bundle_clean_options, ""
+    set :bundle_check_before_install, true
   end
 end

--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -29,7 +29,7 @@ namespace :bundler do
           options << "--gemfile #{fetch(:bundle_gemfile)}" if fetch(:bundle_gemfile)
           options << "--path #{fetch(:bundle_path)}" if fetch(:bundle_path)
 
-          unless fetch(:bundle_check_before_install) && test(:bundle, :check, *options)
+          if fetch(:bundle_check_before_install) && test(:bundle, :check, *options)
             info "The Gemfile's dependencies are satisfied, skipping installation"
           else
             options << "--binstubs #{fetch(:bundle_binstubs)}" if fetch(:bundle_binstubs)


### PR DESCRIPTION
There was some discussion about bypassing the `bundle install test` command during installation in #95. I added an optional setting `bundle_check_before_install` that defaults to `true`. If you manually set to false it will perform a full installation with every deploy.