### PR TITLE
Set Bundler Jobs Default to 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [Unreleased][] (master)
 
 * Your contribution here!
+* Set `bundle_jobs` default to `4` @Tensho
 * When "bundle install" is skipped due to a Gemfile's dependencies are being satisfied, print a message to the log instead of silently skipping
 
 # [1.3.0][] (22 Sep 2017)

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ You can parallelize the installation of gems with bundler's jobs feature.
 Choose a number less or equal than the number of cores your server.
 
 ```ruby
-set :bundle_jobs, 4 # default: nil, only available for Bundler >= 1.4
+set :bundle_jobs, 8 # default: 4, only available for Bundler >= 1.4
 ```
 
 To generate binstubs on each deploy, set `:bundle_binstubs` path:

--- a/capistrano-bundler.gemspec
+++ b/capistrano-bundler.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'capistrano', '~> 3.1'
-  spec.add_dependency 'sshkit', '~> 1.2'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'danger'

--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -81,7 +81,7 @@ namespace :load do
     set :bundle_path, -> { shared_path.join('bundle') }
     set :bundle_without, %w{development test}.join(' ')
     set :bundle_flags, '--deployment --quiet'
-    set :bundle_jobs, nil
+    set :bundle_jobs, 4
     set :bundle_env_variables, {}
     set :bundle_clean_options, ""
   end


### PR DESCRIPTION
Bundler `--jobs` option is loyal to overhead and if you don't have `4` cores it just [fallbacks to `1`](https://github.com/bundler/bundler/blob/d44d803357506895555ff97f73e60d593820a0de/lib/bundler/installer.rb#L200). Even majority of the smartphones has 2+ cores, so it's reasonable to set 4 as default. In this case, the majority of people will leverage on parallelization out of the box without any extra configuration.