### PR TITLE
added support for optional gem groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * Your contribution here!
 
+# [1.5.1][] (08 May 2019)
+
+* Added support for optional gem groups by allowing `:bundle_with, %w{optional_groupA optional_groupB}.join(' ')` to be set so that bundler will execute as: `bundle install --with optional_groupA optional_groupB`
+
 # [1.5.0][] (23 Dec 2018)
 
 Changes to default behavior

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ set :bundle_servers, -> { release_roles(fetch(:bundle_roles)) } # this is defaul
 set :bundle_binstubs, -> { shared_path.join('bin') }            # default: nil
 set :bundle_gemfile, -> { release_path.join('MyGemfile') }      # default: nil
 set :bundle_path, -> { shared_path.join('bundle') }             # this is default. set it to nil for skipping the --path flag.
+set :bundle_with, %w{msql}.join(' ')                            # default: nil
 set :bundle_without, %w{development test}.join(' ')             # this is default
 set :bundle_flags, '--deployment --quiet'                       # this is default
 set :bundle_env_variables, {}                                   # this is default

--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -15,6 +15,7 @@ namespace :bundler do
           set :bundle_binstubs, -> { shared_path.join('bin') }
           set :bundle_gemfile, -> { release_path.join('Gemfile') }
           set :bundle_path, -> { shared_path.join('bundle') }
+          set :bundle_with, nil
           set :bundle_without, %w{development test}.join(' ')
           set :bundle_flags, '--deployment --quiet'
           set :bundle_jobs, nil
@@ -33,6 +34,7 @@ namespace :bundler do
           else
             options << "--binstubs #{fetch(:bundle_binstubs)}" if fetch(:bundle_binstubs)
             options << "--jobs #{fetch(:bundle_jobs)}" if fetch(:bundle_jobs)
+            options << "--with #{fetch(:bundle_with)}" if fetch(:bundle_with)
             options << "--without #{fetch(:bundle_without)}" if fetch(:bundle_without)
             options << "#{fetch(:bundle_flags)}" if fetch(:bundle_flags)
             execute :bundle, :install, *options
@@ -79,6 +81,7 @@ namespace :load do
     set :bundle_binstubs, nil
     set :bundle_gemfile, nil
     set :bundle_path, -> { shared_path.join('bundle') }
+    set :bundle_with, nil
     set :bundle_without, %w{development test}.join(' ')
     set :bundle_flags, '--deployment --quiet'
     set :bundle_jobs, 4


### PR DESCRIPTION
Adds support for including optional gem groups: https://bundler.io/guides/groups.html
The default for this new argument is nil.

For example if the following is in the Gemfile: 
```ruby
group :rollbar , optional: true do
  gem 'rollbar'
end
```

You can add `set :bundle_with, %w{ rollbar }.join(' ')` to your deploy.rb file(s)

So that bundler runs as `bundle install --with rollbar`