### PR TITLE
Upgrade CI to use Ruby 2.7.1 and Bundler 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
-sudo: false
+---
 language: ruby
+cache: bundler
+branches:
+  only:
+    - master
 rvm:
-  - 2.3.3
-before_install: gem install bundler -v '~> 1.14' --conservative
-before_script: bundle exec danger
+  - 2.7.1
+script: bundle exec danger

--- a/capistrano-bundler.gemspec
+++ b/capistrano-bundler.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'capistrano', '~> 3.1'
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'danger'
   spec.add_development_dependency 'rake'
 end


### PR DESCRIPTION
CI has been failing because of and apparent Bundler 1.x vs 2.x issue. Fix by explicitly requiring 2.x and also upgrade to the latest Ruby.