### PR TITLE
Switch to environment variables for defining bundler parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [Unreleased][] (master)
 
-* Switch to using environment variables for deprecated parameters.
+* Switch to using environment variables for [parameters deprecated in preparation for Bundler 3](https://github.com/rubygems/bundler/blob/d4993be66fa2e76b3ca00ea56a51ecab5478b726/UPGRADING.md#bundler-3). This means that if you were overriding `:bundle_env_variables` or depending on `:bundle_without` to remove `--deployment`, you will need to approach those differently.
 * Your contribution here!
 
 # [1.6.0][] (2 Jul 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [Unreleased][] (master)
 
+* Switch to using environment variables for deprecated parameters.
 * Your contribution here!
 
 # [1.6.0][] (2 Jul 2019)

--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -27,14 +27,12 @@ namespace :bundler do
         with fetch(:bundle_env_variables) do
           options = []
           options << "--gemfile #{fetch(:bundle_gemfile)}" if fetch(:bundle_gemfile)
-          options << "--path #{fetch(:bundle_path)}" if fetch(:bundle_path)
 
           if fetch(:bundle_check_before_install) && test(:bundle, :check, *options)
             info "The Gemfile's dependencies are satisfied, skipping installation"
           else
             options << "--binstubs #{fetch(:bundle_binstubs)}" if fetch(:bundle_binstubs)
             options << "--jobs #{fetch(:bundle_jobs)}" if fetch(:bundle_jobs)
-            options << "--without #{fetch(:bundle_without)}" if fetch(:bundle_without)
             options << "#{fetch(:bundle_flags)}" if fetch(:bundle_flags)
             execute :bundle, :install, *options
           end
@@ -81,9 +79,18 @@ namespace :load do
     set :bundle_gemfile, nil
     set :bundle_path, -> { shared_path.join('bundle') }
     set :bundle_without, %w{development test}.join(' ')
-    set :bundle_flags, '--deployment --quiet'
+    set :bundle_flags, '--quiet'
     set :bundle_jobs, 4
-    set :bundle_env_variables, {}
+
+    bundle_default_config = { 'BUNDLE_DEPLOYMENT' => true }
+    if fetch(:bundle_path)
+      bundle_default_config['BUNDLE_PATH'] = fetch(:bundle_path)
+    end
+    if fetch(:bundle_without)
+      bundle_default_config['BUNDLE_WITHOUT'] = fetch(:bundle_without)
+    end
+
+    set :bundle_env_variables, bundle_default_config
     set :bundle_clean_options, ""
     set :bundle_check_before_install, true
   end


### PR DESCRIPTION
Another approach to https://github.com/capistrano/bundler/issues/115

According to the documentation, Bundler can accept these parameters using environment variables. This PR switches the default parameter passing to these variables.

Turns into:
```
  INFO [5d242bfd] Running $HOME/.rbenv/bin/rbenv exec bundle install --jobs 4 --quiet as myuser@example.com
 DEBUG [5d242bfd] Command: cd /home/myuser/myapp/current && ( export RBENV_ROOT="$HOME/.rbenv" RBENV_VERSION="2.7.1" BUNDLE_DEPLOYMENT="true" BUNDLE_PATH="/var/www/shared/bundle" BUNDLE_WITHOUT="development test" ; $HOME/.rbenv/bin/rbenv exec bundle install --jobs 4 --quiet )
```

This will likely require a major version bump, unless we can think through all of the edge cases here.