### PR TITLE
Separate default :bundle_without value with :

### DIFF
--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -109,7 +109,7 @@ namespace :load do
     set :bundle_binstubs, nil
     set :bundle_gemfile, nil
     set :bundle_path, -> { shared_path.join('bundle') }
-    set :bundle_without, %w{development test}.join(' ')
+    set :bundle_without, %w{development test}.join(':')
     set :bundle_flags, '--quiet'
     set :bundle_jobs, 4
     set :bundle_env_variables, {}


### PR DESCRIPTION
The official bundler documentation specifies that the `without` config setting should be a colon-separate value. We were using space-separated for the default value of `"development test"`, which lead to this warning:

```
You are replacing the current local value of without, which is currently "development:test"
```

Fix by changing the default `:bundle_without` value to be `"development:test"` (i.e. colon-separated).

Fixes #125