### PR TITLE
Fix groups separator in bundle_without in the README and task description

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ set :bundle_servers, -> { release_roles(fetch(:bundle_roles)) } # this is defaul
 set :bundle_binstubs, -> { shared_path.join('bin') }            # default: nil
 set :bundle_gemfile, -> { release_path.join('MyGemfile') }      # default: nil
 set :bundle_path, -> { shared_path.join('bundle') }             # this is default. set it to nil to use bundler's default path
-set :bundle_without, %w{development test}.join(' ')             # this is default
+set :bundle_without, %w{development test}.join(':')             # this is default
 set :bundle_flags, '--quiet'                                    # this is default
 set :bundle_env_variables, {}                                   # this is default
 set :bundle_clean_options, ""                                   # this is default. Use "--dry-run" if you just want to know what gems would be deleted, without actually deleting them

--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -46,7 +46,7 @@ namespace :bundler do
           set :bundle_binstubs, nil
           set :bundle_gemfile, -> { release_path.join('Gemfile') }
           set :bundle_path, -> { shared_path.join('bundle') }
-          set :bundle_without, %w{development test}.join(' ')
+          set :bundle_without, %w{development test}.join(':')
           set :bundle_flags, '--quiet'
           set :bundle_jobs, 4
           set :bundle_env_variables, {}


### PR DESCRIPTION
In #126 groups separator in the `bundle_without` config value has been changed from ' ' to ':'. Updating the README and the description of the `install:config` task accordingly