### PR TITLE
Fix deprecation warning with --binstubs flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ set :bundle_roles, :all                                         # this is defaul
 set :bundle_config, { deployment: true }                        # this is default
 set :bundle_servers, -> { release_roles(fetch(:bundle_roles)) } # this is default
 set :bundle_binstubs, -> { shared_path.join('bin') }            # default: nil
+set :bundle_binstubs_command, :install                          # this is default
 set :bundle_gemfile, -> { release_path.join('MyGemfile') }      # default: nil
 set :bundle_path, -> { shared_path.join('bundle') }             # this is default. set it to nil to use bundler's default path
 set :bundle_without, %w{development test}.join(':')             # this is default
@@ -116,6 +117,14 @@ Downsides to cleaning:
 
 * If a rollback requires rebuilding a Gem with a large compiled binary component, such as Nokogiri, the rollback will take a while.
 * In rare cases, if a gem that was used in the previously deployed version was yanked, rollback would entirely fail.
+
+If you're using Bundler >= 2.1 and you are generating binstubs, you can configure capistrano-bundler to use the newer
+`bundle binstubs` command. This will avoid the deprecation warning that you'd otherwise get when using `bundle install`
+to generate binstubs:
+
+```ruby
+set :bundle_binstubs_command, :binstubs
+```
 
 ### Environment Variables
 

--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -60,10 +60,12 @@ namespace :bundler do
             info "The Gemfile's dependencies are satisfied, skipping installation"
           else
             options = []
-            options << "--binstubs #{fetch(:bundle_binstubs)}" if fetch(:bundle_binstubs)
             options << "--jobs #{fetch(:bundle_jobs)}" if fetch(:bundle_jobs)
             options << "#{fetch(:bundle_flags)}" if fetch(:bundle_flags)
             execute :bundle, :install, *options
+            if fetch(:bundle_binstubs)
+              execute :bundle, :binstubs, '--all', '--path', fetch(:bundle_binstubs)
+            end
           end
         end
       end

--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -44,6 +44,7 @@ namespace :bundler do
           set :bundle_config, { deployment: true }
           set :bundle_servers, -> { release_roles(fetch(:bundle_roles)) }
           set :bundle_binstubs, nil
+          set :bundle_binstubs_command, :install
           set :bundle_gemfile, -> { release_path.join('Gemfile') }
           set :bundle_path, -> { shared_path.join('bundle') }
           set :bundle_without, %w{development test}.join(':')
@@ -60,10 +61,15 @@ namespace :bundler do
             info "The Gemfile's dependencies are satisfied, skipping installation"
           else
             options = []
+            if fetch(:bundle_binstubs) &&
+               fetch(:bundle_binstubs_command) == :install
+              options << "--binstubs #{fetch(:bundle_binstubs)}"
+            end
             options << "--jobs #{fetch(:bundle_jobs)}" if fetch(:bundle_jobs)
             options << "#{fetch(:bundle_flags)}" if fetch(:bundle_flags)
             execute :bundle, :install, *options
-            if fetch(:bundle_binstubs)
+            if fetch(:bundle_binstubs) &&
+               fetch(:bundle_binstubs_command) == :binstubs
               execute :bundle, :binstubs, '--all', '--path', fetch(:bundle_binstubs)
             end
           end
@@ -109,6 +115,7 @@ namespace :load do
     set :bundle_config, { deployment: true }
     set :bundle_servers, -> { release_roles(fetch(:bundle_roles)) }
     set :bundle_binstubs, nil
+    set :bundle_binstubs_command, :install
     set :bundle_gemfile, nil
     set :bundle_path, -> { shared_path.join('bundle') }
     set :bundle_without, %w{development test}.join(':')


### PR DESCRIPTION
The --binstubs flag to bundle install is deprecated and raises a deprecation warning in more recent versions of bundler. From [rubygems/bundler/UPGRADING.md](https://github.com/rubygems/bundler/blob/master/UPGRADING.md):

> The bundle install command will no longer accept a --binstubs flag.
>
> The --binstubs option has been removed from bundle install and replaced with the bundle binstubs command. The --binstubs flag would create binstubs for all executables present inside the gems in the project. This was hardly useful since most users will only use a subset of all the binstubs available to them. Also, it would force the introduction of a bunch of most likely unused files into source control. Because of this, binstubs now must be created and checked into version control individually.

I've updated the bundle install task to run the equivalent command with [bundle binstubs](https://bundler.io/man/bundle-binstubs.1.html) instead of using the --binstubs flag with bundle install to fix the deprecation warning. I'm not sure if this is the preferred solution since it makes the install task run an additional command, but it seems reasonable to me because it accomplishes the same goal.