### PR TITLE
Default to Bundler 4 in 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add these lines to your application's Gemfile **[Recommended]**:
 
 ```ruby
 gem 'capistrano', '~> 3.6'
-gem 'capistrano-bundler', '~> 2.0'
+gem 'capistrano-bundler', '~> 3.0'
 ```
 
 And then execute:
@@ -83,14 +83,14 @@ set :bundle_flags, '--quiet'                                    # this is defaul
 set :bundle_env_variables, {}                                   # this is default
 set :bundle_clean_options, ""                                   # this is default. Use "--dry-run" if you just want to know what gems would be deleted, without actually deleting them
 set :bundle_check_before_install, true                          # default: true. Set this to false to bypass running `bundle check` before executing `bundle install`
-set :bundle_version, 2                                          # default: 2. Set to 4 for Bundler 4 compatibility
+set :bundle_version, 4                                          # default: 4. Set to 2 for Bundler 2 compatibility
 ```
 
-If you are using Bundler 4 (which is the default in Ruby 4),
-make sure to set `:bundle_version` to avoid deprecation warnings:
+Bundler 4 is the default in Ruby 4. If your deploy target still uses Bundler 2,
+set `:bundle_version` explicitly:
 
 ```ruby
-set :bundle_version, 4
+set :bundle_version, 2
 ```
 
 You can parallelize the installation of gems with bundler's jobs feature.

--- a/capistrano-bundler.gemspec
+++ b/capistrano-bundler.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'capistrano-bundler'
-  spec.version       = '2.2.0'
+  spec.version       = '3.0.0'
   spec.license       = 'MIT'
   spec.authors       = ['Tom Clements', 'Lee Hambley', 'Kir Shatrov']
   spec.email         = ['seenmyfate@gmail.com', 'lee.hambley@gmail.com', 'shatrov@me.com']

--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -16,7 +16,7 @@ namespace :bundler do
     on fetch(:bundle_servers) do
       within release_path do
         with fetch(:bundle_env_variables) do
-          config_args = fetch(:bundle_version, 2) >= 4 ? %w[config set] : %w[config]
+          config_args = fetch(:bundle_version, 4) >= 4 ? %w[config set] : %w[config]
 
           configuration = fetch(:bundle_config).dup || {}
           configuration[:gemfile] = fetch(:bundle_gemfile)
@@ -55,7 +55,7 @@ namespace :bundler do
           set :bundle_env_variables, {}
           set :bundle_clean_options, ""
           set :bundle_check_before_install, true
-          set :bundle_version, 2
+          set :bundle_version, 4
     DESC
   task install: :config do
     on fetch(:bundle_servers) do
@@ -128,6 +128,6 @@ namespace :load do
     set :bundle_env_variables, {}
     set :bundle_clean_options, ""
     set :bundle_check_before_install, true
-    set :bundle_version, 2
+    set :bundle_version, 4
   end
 end


### PR DESCRIPTION
Switch capistrano-bundler's default `bundle_version` from 2 to 4 so new installs use Bundler 4's config behavior without requiring extra deploy configuration.

Update the README to document the new default and how to opt back into Bundler 2 for older deploy targets, and bump the gem version to 3.0.0 to reflect the breaking default change.

Close #138

---

## Manual tests

### With `set :bundle_version, 4`

```
00:00 bundler:config
      01 bundle config set --local deployment true
      02 bundle config set --local force_ruby_platform true
```

### Without `set :bundle_version`

```
00:00 bundler:config
      01 bundle config set --local deployment true
      02 bundle config set --local force_ruby_platform true
```

### With `set :bundle_version, 2`

```
00:00 bundler:config
      01 bundle config --local deployment true
      02 bundle config --local force_ruby_platform true
```

## Note

The major bump will also require a new release of `capistrano-rails` to allow `capistrano-bundler` 3.x